### PR TITLE
Adding proxy support to build file

### DIFF
--- a/ant/solenopsis.xml
+++ b/ant/solenopsis.xml
@@ -26,4 +26,11 @@
     <property name="solenopsis.bsh.HOME" value="${solenopsis.root.HOME}/../bsh"/>
 
 	<import file="${solenopsis.VERSION}/solenopsis-build.xml"/>
+	<target name="proxy">
+		<property name="proxy.port" value="${solenopsis.proxy.port}"/>
+		<property name="proxy.user" value="${solenopsis.proxy.user}"/>
+		<property name="proxy.pass" value="${solenopsis.proxy.pass}"/>
+		<property name="proxy.host" value="${solenopsis.proxy.host}"/>
+		<setproxy proxyhost="${proxy.host}" proxyport="${proxy.port}" proxyuser="${proxy.user}" proxypassword="${proxy.pass}"/>
+    	</target>
 </project>


### PR DESCRIPTION
Add optional proxy support task for ant build file, example usage: $ solenopsis proxy pull
Needed properties at solenopsis.properties file

solenopsis.proxy.port=8080
solenopsis.proxy.user=proxyUsername
solenopsis.proxy.pass=mySuperSecretPass
solenopsis.proxy.host=proxy.domain.com