### PR TITLE
Added installing with homebrew support

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -47,46 +47,6 @@ else
 	cd ${RUN_DIR}
 fi
 
-echo "Installing solenopsis"
-
-mkdir -p /usr/share/solenopsis/config
-mkdir -p /usr/share/solenopsis/docs
-mkdir -p /usr/share/solenopsis/ant
-mkdir -p /usr/share/solenopsis/ant/lib
-mkdir -p /usr/share/solenopsis/ant/lib/1.8.4
-mkdir -p /usr/share/solenopsis/ant/lib/1.9.1
-mkdir -p /usr/share/solenopsis/ant/1.1/lib
-mkdir -p /usr/share/solenopsis/ant/1.1/properties
-mkdir -p /usr/share/solenopsis/ant/1.1/templates
-mkdir -p /usr/share/solenopsis/ant/1.1/util
-mkdir -p /usr/share/solenopsis/ant/1.2/bsh
-mkdir -p /usr/share/solenopsis/ant/1.2/lib
-mkdir -p /usr/share/solenopsis/ant/1.2/properties
-mkdir -p /usr/share/solenopsis/ant/1.2/xslt
-mkdir -p /usr/share/solenopsis/scripts
-mkdir -p /usr/share/solenopsis/scripts/lib
-mkdir -p /usr/share/solenopsis/scripts/templates
-
-cp config/defaults.cfg /usr/share/solenopsis/config/
-cp docs/* /usr/share/solenopsis/docs/
-cp -rf ant /usr/share/solenopsis
-cp scripts/solenopsis /usr/share/solenopsis/scripts/
-cp scripts/bsolenopsis /usr/share/solenopsis/scripts/
-cp scripts/lib/* /usr/share/solenopsis/scripts/lib/
-cp scripts/templates/* /usr/share/solenopsis/scripts/templates/
-cp scripts/solenopsis-profile.sh /usr/share/solenopsis/scripts/
-
-
-rm -rf /usr/share/solenopsis/scripts/*.pyc
-rm -rf /usr/share/solenopsis/scripts/*.pyo
-rm -rf /usr/share/solenopsis/scripts/lib/*.pyc
-rm -rf /usr/share/solenopsis/scripts/lib/*.pyo
-
-chmod 755 /usr/share/solenopsis/scripts/*
-
-ln -sf /usr/share/solenopsis/scripts/solenopsis /usr/bin/solenopsis
-ln -sf /usr/share/solenopsis/scripts/bsolenopsis /usr/bin/bsolenopsis
-ln -sf /usr/share/solenopsis/scripts/solenopsis-profile.sh /etc/profile.d/solenopsis-profile.sh
 
 #
 # Take OSX, Linux, etc into account...
@@ -94,15 +54,74 @@ ln -sf /usr/share/solenopsis/scripts/solenopsis-profile.sh /etc/profile.d/soleno
 RUNNING_OS=`uname -a | cut -f 1 -d ' '`
 
 case $RUNNING_OS in
-    Linux) SOLENOPSIS_BASH_COMPLETION_HOME=/etc/bash_completion.d
+    Linux)
+	SOLENOPSIS_BASH_COMPLETION_HOME=/etc/bash_completion.d
+	SOLENOPSIS_INSTALL_HOME=/usr/share
+	SOLENOPSIS_BINARIES=/usr/bin
+	SOLENOPSIS_PROFILE_PATH=/etc/profile.d
         ;;
-    Darwin) SOLENOPSIS_BASH_COMPLETION_HOME=/usr/local/etc/bash_completion.d
+    Darwin)
+	SOLENOPSIS_BASH_COMPLETION_HOME=/usr/local/etc/bash_completion.d
+	SOLENOPSIS_BINARIES=/usr/local/bin
+	SOLENOPSIS_PROFILE_PATH=
+	if type brew >/dev/null; then
+		SOLENOPSIS_INSTALL_HOME=/usr/local/Cellar
+	else
+		SOLENOPSIS_INSTALL_HOME=/usr/share
+	fi
+        ;;
+esac
+
+echo "Installing solenopsis"
+
+mkdir -p $SOLENOPSIS_INSTALL_HOME/solenopsis/config
+mkdir -p $SOLENOPSIS_INSTALL_HOME/solenopsis/docs
+mkdir -p $SOLENOPSIS_INSTALL_HOME/solenopsis/ant
+mkdir -p $SOLENOPSIS_INSTALL_HOME/solenopsis/ant/lib
+mkdir -p $SOLENOPSIS_INSTALL_HOME/solenopsis/ant/lib/1.8.4
+mkdir -p $SOLENOPSIS_INSTALL_HOME/solenopsis/ant/lib/1.9.1
+mkdir -p $SOLENOPSIS_INSTALL_HOME/solenopsis/ant/1.1/lib
+mkdir -p $SOLENOPSIS_INSTALL_HOME/solenopsis/ant/1.1/properties
+mkdir -p $SOLENOPSIS_INSTALL_HOME/solenopsis/ant/1.1/templates
+mkdir -p $SOLENOPSIS_INSTALL_HOME/solenopsis/ant/1.1/util
+mkdir -p $SOLENOPSIS_INSTALL_HOME/solenopsis/ant/1.2/bsh
+mkdir -p $SOLENOPSIS_INSTALL_HOME/solenopsis/ant/1.2/lib
+mkdir -p $SOLENOPSIS_INSTALL_HOME/solenopsis/ant/1.2/properties
+mkdir -p $SOLENOPSIS_INSTALL_HOME/solenopsis/ant/1.2/xslt
+mkdir -p $SOLENOPSIS_INSTALL_HOME/solenopsis/scripts
+mkdir -p $SOLENOPSIS_INSTALL_HOME/solenopsis/scripts/lib
+mkdir -p $SOLENOPSIS_INSTALL_HOME/solenopsis/scripts/templates
+
+cp config/defaults.cfg $SOLENOPSIS_INSTALL_HOME/solenopsis/config/
+cp docs/* $SOLENOPSIS_INSTALL_HOME/solenopsis/docs/
+cp -rf ant $SOLENOPSIS_INSTALL_HOME/solenopsis
+cp scripts/solenopsis $SOLENOPSIS_INSTALL_HOME/solenopsis/scripts/
+cp scripts/bsolenopsis $SOLENOPSIS_INSTALL_HOME/solenopsis/scripts/
+cp scripts/lib/* $SOLENOPSIS_INSTALL_HOME/solenopsis/scripts/lib/
+cp scripts/templates/* $SOLENOPSIS_INSTALL_HOME/solenopsis/scripts/templates/
+cp scripts/solenopsis-profile.sh $SOLENOPSIS_INSTALL_HOME/solenopsis/scripts/
+
+
+rm -rf $SOLENOPSIS_INSTALL_HOME/solenopsis/scripts/*.pyc
+rm -rf $SOLENOPSIS_INSTALL_HOME/solenopsis/scripts/*.pyo
+rm -rf $SOLENOPSIS_INSTALL_HOME/solenopsis/scripts/lib/*.pyc
+rm -rf $SOLENOPSIS_INSTALL_HOME/solenopsis/scripts/lib/*.pyo
+
+chmod 755 $SOLENOPSIS_INSTALL_HOME/solenopsis/scripts/*
+
+ln -sf $SOLENOPSIS_INSTALL_HOME/solenopsis/scripts/solenopsis $SOLENOPSIS_BINARIES/solenopsis
+ln -sf $SOLENOPSIS_INSTALL_HOME/solenopsis/scripts/bsolenopsis $SOLENOPSIS_BINARIES/bsolenopsis
+
+case $RUNNING_OS in
+    Linux)
+	SOLENOPSIS_BASH_COMPLETION_HOME=/etc/bash_completion.d
+	ln -sf $SOLENOPSIS_INSTALL_HOME/solenopsis/scripts/solenopsis-profile.sh $SOLENOPSIS_PROFILE_PATH/solenopsis-profile.sh
         ;;
 esac
 
 if [ -d "${SOLENOPSIS_BASH_COMPLETION_HOME}" ]
 then
-    ln -sf /usr/share/solenopsis/scripts/solenopsis-completion.bash ${SOLENOPSIS_BASH_COMPLETION_HOME}/solenopsis-completion.bash
+    ln -sf $SOLENOPSIS_INSTALL_HOME/solenopsis/scripts/solenopsis-completion.bash ${SOLENOPSIS_BASH_COMPLETION_HOME}/solenopsis-completion.bash
 else
     echo "WARNING:  Bash completion dir [${SOLENOPSIS_BASH_COMPLETION_HOME}] for [${RUNNING_OS}] does not exist.  Ignoring solenopsis completion script."
 fi

--- a/uninstall.sh
+++ b/uninstall.sh
@@ -22,9 +22,32 @@
 
 echo "Cleaning up solenopsis"
 
-rm -f /usr/bin/solenopsis
-rm -f /usr/bin/bsolenopsis
-rm -f /etc/bash_completion.d/solenopsis-completion.bash
-rm -f /etc/profile.d/solenopsis-profile.sh
+#
+# Take OSX, Linux, etc into account...
+#
+RUNNING_OS=`uname -a | cut -f 1 -d ' '`
 
-rm -rf /usr/share/solenopsis
+case $RUNNING_OS in
+    Linux)
+	SOLENOPSIS_BASH_COMPLETION_HOME=/etc/bash_completion.d
+	SOLENOPSIS_INSTALL_HOME=/usr/share
+	SOLENOPSIS_BINARIES=/usr/bin
+    rm -f /etc/bash_completion.d/solenopsis-completion.bash
+    rm -f /etc/profile.d/solenopsis-profile.sh
+        ;;
+    Darwin)
+	SOLENOPSIS_BASH_COMPLETION_HOME=/usr/local/etc/bash_completion.d
+	SOLENOPSIS_BINARIES=/usr/local/bin
+	SOLENOPSIS_PROFILE_PATH=
+	if type brew >/dev/null; then
+		SOLENOPSIS_INSTALL_HOME=/usr/local/Cellar
+	else
+		SOLENOPSIS_INSTALL_HOME=/usr/share
+	fi
+        ;;
+esac
+
+rm -f $SOLENOPSIS_BINARIES/solenopsis
+rm -f $SOLENOPSIS_BINARIES/bsolenopsis
+
+rm -rf $SOLENOPSIS_INSTALL_HOME/solenopsis


### PR DESCRIPTION
Brew doesn't install with sudo, and so we can't write to /usr/bin
when installing with brew.  Install to /usr/local/bin instead.