### PR TITLE
Resolves #234 - Set default git protocol to https

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -25,12 +25,19 @@ RUN_DIR=`dirname $0`
 ${RUN_DIR}/uninstall.sh
 
 RUN_LOCAL=""
+GIT_PROTOCOL="https"
 
 for PARAM in $*
 do
 	if [ "${PARAM}" = "--local" ]
 	then
 		RUN_LOCAL=${PARAM}
+	elif [ "${PARAM}" = "--use-git" ]
+	then
+		GIT_PROTOCOL="git"
+	elif [ "${PARAM}" = "--use-ssh" ]
+	then
+		GIT_PROTOCOL="ssh"
 	fi
 done
 
@@ -40,7 +47,9 @@ then
 
 	rm -rf Solenopsis
 
-	git clone git://github.com/solenopsis/Solenopsis.git
+	CLONE_CMD="git clone ${GIT_PROTOCOL}://github.com/solenopsis/Solenopsis.git"
+	echo "${CLONE_CMD}"
+	`${CLONE_CMD}`
 
 	cd Solenopsis
 else


### PR DESCRIPTION
#234 The recommended protocol for communicating with github is https.  This
change sets the default protocol for cloning the repository to https.

Add command line options '--use-git' and '--use-ssh' to install.sh.
This will allow users to specify which protocol to use when cloning
the repository.

install.sh will now print the `git clone` command to stdout.