### PR TITLE
Simplify call to uname(1)

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -88,10 +88,7 @@ ln -sf /usr/share/solenopsis/scripts/solenopsis /usr/bin/solenopsis
 ln -sf /usr/share/solenopsis/scripts/bsolenopsis /usr/bin/bsolenopsis
 ln -sf /usr/share/solenopsis/scripts/solenopsis-profile.sh /etc/profile.d/solenopsis-profile.sh
 
-#
-# Take OSX, Linux, etc into account...
-#
-RUNNING_OS=`uname -a | cut -f 1 -d ' '`
+RUNNING_OS=`uname -s`
 
 case $RUNNING_OS in
     Linux) SOLENOPSIS_BASH_COMPLETION_HOME=/etc/bash_completion.d


### PR DESCRIPTION
Modify call to uname(1) to utilize the -s option instead of getting
`uname -a` and then using cut(1) to extract the kernel/system name.
The -s option is POSIX compliant and supported on osx/linux/etc...

A nonexhaustive list of the output of uname(1) for various operating
systems can be found here: [https://en.wikipedia.org/wiki/Uname](https://en.wikipedia.org/wiki/Uname)

Remove unnecessary comment.