### PR TITLE
Fix #40: Correct variable in fileDestructivePush

### DIFF
--- a/scripts/lib/ant.py
+++ b/scripts/lib/ant.py
@@ -163,7 +163,7 @@ def fileDestructivePush(fileList):
 
     if fullList != '':
         fullList = fullList[:-1]
-        addFlag('%s=\'%s\'' % ('sf.files2remove', fileList,))
+        addFlag('%s=\'%s\'' % ('sf.files2remove', fullList,))
         runAnt('file-destructive-push')
     else:
         logger.critical('Unable to find any files to push.')


### PR DESCRIPTION
## Summary

Fixes #40 - When performing destructive-pushes, if the last filter is deleted it breaks

## The Bug

In `scripts/lib/ant.py` line 166, the `fileDestructivePush()` function was passing `fileList` (the original array of filenames parameter) instead of `fullList` (the processed string of full paths with delimiters) to the `addFlag()` call.

This caused the Ant task to receive a Python array `['file1.cls', 'file2.cls']` when it expected a delimited string of full paths like `/path/to/file1.cls:/path/to/file2.cls`.

## The Fix

Changed line 166 from:
```python
addFlag('%s=\'%s\'' % ('sf.files2remove', fileList,))
```

to:
```python
addFlag('%s=\'%s\'' % ('sf.files2remove', fullList,))
```

This matches the correct pattern used in `filePush()` at line 133.

## Test Evidence

Before fix: Function passes `['test1.cls', 'test2.cls']` (array)
After fix: Function passes `/tmp/test/test1.cls:/tmp/test/test2.cls` (string)

The fix is a single-character change (1 line in 1 file) that corrects a copy-paste error where the wrong variable was used.

## Test plan

- [x] Python syntax validation passes
- [x] Variable type matches expected Ant parameter format
- [x] Pattern matches successful `filePush()` implementation
- [ ] Manual test with actual SFDC destructive push operation

Generated with Claude Code