### PR TITLE
Fix #137: Preserve directory structure for metadata files with '/' in names

### DIFF
--- a/ant/1.1/util/sfdc-util.xml
+++ b/ant/1.1/util/sfdc-util.xml
@@ -4168,7 +4168,25 @@ ${sfdc-util.SF-JAR.PATH}
 								Iterate over the files, populating the report and package properties...
 							-->
 							<rh-util:processList param="dir.LIST-VALS" list="${diff.FILE-MISSING}" listDelimiter=":">
-								<rh-util:baseName-List property="dir.FILE" file="@{dir.LIST-VALS}" suffixList="${sf.suffix.@{dir.SUB-DIR}}"/>
+								<!--
+									Strip suffix(es) from the file path while preserving directory structure.
+									baseName-List incorrectly removes directory components, breaking files with "/" in names.
+									Fix for issue #137: metadata file names can contain "/" as part of the name.
+								-->
+								<ac:var name="dir.FILE" value="@{dir.LIST-VALS}"/>
+								<rh-util:ifNotEqual arg1="${sf.suffix.@{dir.SUB-DIR}}" arg2="">
+									<rh-util:then>
+										<!-- Strip each suffix from the path, preserving directory structure -->
+										<rh-util:processList param="dir.SUFFIX" list="${sf.suffix.@{dir.SUB-DIR}}" listDelimiter=" ">
+											<ac:propertyregex property="dir.FILE"
+											                  override="true"
+											                  input="${dir.FILE}"
+											                  regexp="\.@{dir.SUFFIX}$"
+											                  replace=""
+											                  defaultValue="${dir.FILE}"/>
+										</rh-util:processList>
+									</rh-util:then>
+								</rh-util:ifNotEqual>
 
 								<rh-util:appendProperty name="@{reportProperty}" value="        @{dir.LIST-VALS}  (${dir.FILE})${line.separator}"/>
 


### PR DESCRIPTION
## Summary

Fixes #137 - The `report-diff` task now correctly handles metadata files that contain `/` characters in their names.

## Problem

When metadata file names contain `/` (e.g., reports named "Sales/Q1Report"), the report-diff task was incorrectly:
1. Treating the `/` as a path separator
2. Stripping directory components  
3. Ignoring these files in diff reports
4. Attempting to create them as "new" components when pushed

## Root Cause

The `baseName-List` macro in the `diff` task (line 4171 of `ant/1.1/util/sfdc-util.xml`) uses Ant's `basename` task, which removes ALL directory components from paths. For folder-based metadata like reports/dashboards, this broke files where the metadata name itself legitimately contains `/`.

**Example failure:**
- Input file: `reports/UnfiledPublic/Sales/Q1Report.report`
- baseName-List output: `"Q1Report"` ❌ (lost `"UnfiledPublic/Sales/"`)
- Expected output: `"UnfiledPublic/Sales/Q1Report"` ✅

## Solution

Replaced the `baseName-List` call with manual suffix stripping using `propertyregex` that:
- Preserves the full relative path from the metadata type directory
- Only strips file extension suffixes (`.report`, `.dashboard`, etc.)
- Correctly handles both actual subdirectories AND names containing `/`

## Changes

- **ant/1.1/util/sfdc-util.xml** (line 4171): Replace `baseName-List` with `propertyregex`-based suffix removal
- 19 lines added (includes comments), 1 line removed
- Minimal, scoped fix affecting only folder-based metadata diff processing

## Test Evidence

**Before fix:**
- Metadata files with `/` in names were ignored by `report-diff`
- These files were treated as "new" components on push

**After fix:**
- Files with `/` in names correctly appear in diff reports
- Included in deployment packages with proper relative paths
- No longer incorrectly flagged as "new" components

## Verification

The fix preserves backward compatibility:
- Files without `/` in names: No behavior change
- Files with `/` in names: Now handled correctly
- All other metadata types: Unaffected

---

Generated with Claude Code