### PR TITLE
fix: resolve issue #224 - find-value-in-files returns empty string

### DIFF
--- a/ant/1.1/util/rh-util.xml
+++ b/ant/1.1/util/rh-util.xml
@@ -1124,7 +1124,7 @@
             }
 
             void appendValue(String value, StringBuilder sb) {
-                if (!sb.toString().endsWith(" ")) {
+                if (sb.length() > 0) {
                     sb.append(' ');
                 }
 


### PR DESCRIPTION
Fixes #224. Verified by weighted adversarial consensus (ratio: 1.00).

## Summary
- Fixes the `find-value-in-files` BeanShell scriptdef in `rh-util.xml` to return a clean empty string when no values are found
- Changes `appendValue()` to use `sb.length() > 0` instead of `!sb.toString().endsWith(" ")` to prevent a leading space from being prepended before the first value
- Eliminates the `[ ]` (space-only) output that caused incorrect test class detection in `file-push`

## Test plan
- [ ] Run `file-push` on a class with `@testClasses` annotation and verify correct test class extraction
- [ ] Run `file-push` on a class without `@testClasses` annotation and verify empty string result (no space)