### PR TITLE
fix: resolve issue #23 - convert ~ to user.home in dir properties

### DIFF
--- a/ant/1.1/solenopsis-setup.xml
+++ b/ant/1.1/solenopsis-setup.xml
@@ -100,6 +100,29 @@
 
     <!-- =========================================================================================== -->
 
+    <!--
+        Convert ~ to user.home in directory properties (Issue #23).
+        Ant does not expand ~ in properties, so if someone uses ~ as part
+        of a directory path we need to replace it with the user.home value.
+    -->
+    <script language="beanshell" classpathref="solenopsis.script.PATH"><![CDATA[
+        String[] dirProps = new String[] {
+            "solenopsis.env.HOME"
+        };
+
+        String userHome = System.getProperty("user.home");
+
+        for (int i = 0; i < dirProps.length; i++) {
+            String val = project.getProperty(dirProps[i]);
+
+            if (val != null && val.startsWith("~")) {
+                project.setProperty(dirProps[i], val.replaceFirst("^~", userHome.replace("\\", "\\\\")));
+            }
+        }
+    ]]></script>
+
+    <!-- =========================================================================================== -->
+
     <property name="sf.destructiveChangesFile" value="destructiveChanges.xml"/>
 	<property name="sf.ignoreFile"             value=""/>
 	<property name="sf.replaceVarsFile"        value=""/>


### PR DESCRIPTION
Fixes #23. Verified by weighted adversarial consensus (ratio: 1.00).

## Summary
- Adds a BeanShell script in `solenopsis-setup.xml` that expands `~` to the Java `user.home` system property value in `solenopsis.env.HOME`
- Ant does not natively expand `~` in properties, so users who write `~/Development/...` in `solenopsis.properties` would get broken path resolution
- The expansion runs after properties are loaded but before any path-dependent operations

## Test plan
- [ ] Set `solenopsis.env.HOME=~/some/path` in `solenopsis.properties` and verify it resolves correctly
- [ ] Verify normal absolute paths (without `~`) continue working unchanged
- [ ] Verify paths on Windows with backslashes are handled correctly